### PR TITLE
3 feature request support reading of current value of a watched pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,33 @@
 # OpenGPIO
+
 A performant c++ based general purpose GPIO controller for linux devices.
 OpenGPIO is written using libgpiod, line & chip based abstractions.
 
 While this library can be used on most devices, you'll need to know the chip and line numbers corrisponding to the GPIO pin you want to access. This information can usually be found in the datasheet for your devices SOC. If all that sounds way to complicated, you can make use of one of the official device drivers which already have the bcm and board pin mappings for GPIO pins.
 
 ## Prerequisites
-- libgpiod: `sudo apt install -y libgpiod-dev` - This library requires libgpiod-dev to be installed before installing via npm.
+
+-   libgpiod: `sudo apt install -y libgpiod-dev` - This library requires libgpiod-dev to be installed before installing via npm.
 
 ## Supported Features
-- GPIO - General purpose input output.
-- PWM (via GPIO) - GPIO based pulse width modulation.
-- Events - Event callbacks for rising, falling, or both edges.
+
+-   GPIO - General purpose input output.
+-   PWM (via GPIO) - GPIO based pulse width modulation.
+-   Events - Event callbacks for rising, falling, or both edges.
 
 ## Unsupported Features
-- PWM (Native PWM) - This library does not yet support native PWM, only emulated PWM via GPIO.
-- I2C - Use the openi2c library for common i2c module drivers, or alternatively we recommending using the i2c-bus library directly.
+
+-   PWM (Native PWM) - This library does not yet support native PWM, only emulated PWM via GPIO.
+-   I2C - Use the openi2c library for common i2c module drivers, or alternatively we recommending using the i2c-bus library directly.
 
 ## Official Device Drivers
-- NanoPI NEO3
+
+-   NanoPI NEO3
 
 ## Using An Official Driver
+
 Using an official device driver is simple, just import the device by its name.
+
 ```ts
 import { NanoPi_NEO3, Edge } from 'opengpio';
 
@@ -31,14 +38,18 @@ output.value = false; // Set the NanoPi_NEO3's GPIO3_B0 pin low
 
 // GPIO Input
 const input = NanoPi_NEO3.input(NanoPi_NEO3.bcm.GPIO3_B0);
-console.log(input.value) // Gets the NanoPi_NEO3's GPIO3_B0 pin high/low value as true/false
+console.log(input.value); // Gets the NanoPi_NEO3's GPIO3_B0 pin high/low value as true/false
 
 // GPIO Events
 // Creates a listener for events on the NanoPi_NEO3's GPIO3_B0 pin for both Rising and Falling edges.
+// Available Events: "change", "rise", "fall"
 const watch = NanoPi_NEO3.watch(NanoPi_NEO3.bcm.GPIO3_B0, Edge.Both);
-watch.on('event', (value) => {
+watch.on('change', (value) => {
     console.log(value); // Contains the high/low value as true/false
 });
+
+// Get the current value of the watch
+console.log(watch.value);
 
 // GPIO PWM
 // Creates a 50hz (20ms) PWM on the NanoPi NEO3's GPIO3_B0 pin, with a duty cycle of 10% (2ms)
@@ -46,9 +57,10 @@ const pwm = NanoPi_NEO3.pwm(NanoPi_NEO3.bcm.GPIO3_B0, 0.1, 50);
 pwm.setDutyCycle(0.2); // Updates the duty cycle of the pwm to 20% (4ms)
 ```
 
-
 ## Using An Unofficial Driver
+
 If no official driver exists, you can use the Default device and provide the chip and line numbers directly. Otherwise, usage is identical.
+
 ```ts
 import { Default, Edge } from 'opengpio';
 

--- a/cpp/opengpio.cpp
+++ b/cpp/opengpio.cpp
@@ -77,6 +77,11 @@ Napi::Array GpioWatch(Napi::CallbackInfo const &info)
 
     line.request({resourceName, gpiod::line_request::EVENT_BOTH_EDGES, 0}, 0);
 
+    Napi::Function getter = Napi::Function::New(info.Env(), [line](const Napi::CallbackInfo &info)
+                                                {
+        bool value = line.get_value();
+        return Napi::Boolean::New(info.Env(), value); });
+
     WatchContext *data = new WatchContext();
     data->line = line;
     data->active = true;
@@ -119,8 +124,9 @@ Napi::Array GpioWatch(Napi::CallbackInfo const &info)
     Napi::Function cleanup = Napi::Function::New(info.Env(), [data](const Napi::CallbackInfo &info)
                                                  { data->active = false; });
 
-    Napi::Array arr = Napi::Array::New(info.Env(), 1);
-    arr.Set(0u, cleanup);
+    Napi::Array arr = Napi::Array::New(info.Env(), 2);
+    arr.Set(0u, getter);
+    arr.Set(1u, cleanup);
 
     return arr;
 }

--- a/src/classes/Watch.ts
+++ b/src/classes/Watch.ts
@@ -1,9 +1,10 @@
-import { WatchCallback, Gpio, Edge, CleanupCallback } from '../types';
+import { WatchCallback, Gpio, Edge, CleanupCallback, PinGetter } from '../types';
 import lib from '../lib';
 import { EventEmitter } from 'events';
 
 export class Watch extends EventEmitter {
-    private cleanup: CleanupCallback = () => {};
+    private getter: PinGetter = () => false;
+    private cleanup: CleanupCallback = () => { };
     private stopped: boolean = false;
 
     constructor(
@@ -11,7 +12,7 @@ export class Watch extends EventEmitter {
         private edge: Edge
     ) {
         super();
-        const [cleanup] = lib.watch(gpio.chip, gpio.line, (value) => {
+        const [getter, cleanup] = lib.watch(gpio.chip, gpio.line, (value) => {
             if (value && (edge === Edge.Rising || edge === Edge.Both)) {
                 console.log('Rising Event', value);
                 // Has risen to true
@@ -24,6 +25,10 @@ export class Watch extends EventEmitter {
         });
 
         this.cleanup = cleanup;
+    }
+
+    get value() {
+        return this.getter();
     }
 
     stop() {

--- a/src/classes/Watch.ts
+++ b/src/classes/Watch.ts
@@ -17,10 +17,14 @@ export class Watch extends EventEmitter {
                 console.log('Rising Event', value);
                 // Has risen to true
                 this.emit('event', value);
+                this.emit('change', value);
+                this.emit('rise', value);
             } else if (!value && (edge === Edge.Falling || edge === Edge.Both)) {
                 console.log('Falling Event', value);
                 // Has fallen to false
                 this.emit('event', value);
+                this.emit('change', value);
+                this.emit('fall', value);
             }
         });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export type FrequencySetter = (frequency: number) => void;
 export type CleanupCallback = () => void;
 export type PinSetter = (value: boolean) => void;
 export type PinGetter = () => boolean;
-export type WatchCallback = (value:boolean) => void;
+export type WatchCallback = (value: boolean) => void;
 
 export type OpenGpioBindings = {
     info: () => string;
@@ -25,7 +25,7 @@ export type OpenGpioBindings = {
         chip: number,
         line: number,
         callback: WatchCallback,
-    ) => [CleanupCallback];
+    ) => [PinGetter, CleanupCallback];
     pwm: (
         chip: number,
         line: number,

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,4 @@
+# Testing
+This library still needs decent unit tests especially against the c++ code. 
+
+For the moment, this folder contains files which can be used to run various functionality to test if it functions as expected.

--- a/test/watch.ts
+++ b/test/watch.ts
@@ -5,6 +5,6 @@ watch.on('change', (value) => {
     console.log(`Edge detected: ${value}`);
 });
 
-setTimeout(() => {
+setInterval(() => {
     console.log('Value', watch.value);
 }, 1000);

--- a/test/watch.ts
+++ b/test/watch.ts
@@ -1,2 +1,10 @@
 import { NanoPi_NEO3, Edge } from '../src/';
-NanoPi_NEO3.
+
+const watch = NanoPi_NEO3.watch(NanoPi_NEO3.bcm.GPIO0_D3, Edge.Rising);
+watch.on('change', (value) => {
+    console.log(`Edge detected: ${value}`);
+});
+
+setTimeout(() => {
+    console.log('Value', watch.value);
+}, 1000);

--- a/test/watch.ts
+++ b/test/watch.ts
@@ -1,0 +1,2 @@
+import { NanoPi_NEO3, Edge } from '../src/';
+NanoPi_NEO3.


### PR DESCRIPTION
- Added the ability to get the current value of a watched pin.
- Renamed watch event "event" to "change", "event" is still valid and will remain in the events but "change" seems to be a more relevant name. I also added "rise" and "fall" events.