### PR TITLE
Add GPIO pin selection support and remove legacy event handling

### DIFF
--- a/src/classes/Device.ts
+++ b/src/classes/Device.ts
@@ -8,20 +8,37 @@ export class Device {
     static board: Record<number, Gpio> = {};
     static bcm: Record<string, Gpio> = {};
 
-    static input(gpio: Gpio, options: Omit<GpioInputOptions, 'debounce'> = {}) {
-        return new Input(gpio, options);
+    // input<T = typeof this>(gpio: Gpio | keyof T['board'] | keyof T['bcm'] | number) {
+    static input<T extends typeof Device>(this: T, gpio: Gpio | keyof T['board'] | keyof T['bcm'], options: Omit<GpioInputOptions, 'debounce'> = {}): Input {
+        const resolvedGpio = this.getGpioFromIdentifier(gpio);
+        return new Input(resolvedGpio, options);
     }
-    static output(gpio: Gpio, options: GpioOutputOptions = {}) {
-        return new Output(gpio, options);
+    static output<T extends typeof Device>(this: T, gpio: Gpio | keyof T['board'] | keyof T['bcm'], options: GpioOutputOptions = {}): Output {
+        const resolvedGpio = this.getGpioFromIdentifier(gpio);
+        return new Output(resolvedGpio, options);
     }
-    static watch(
-        gpio: Gpio,
+    static watch<T extends typeof Device>(this: T,
+        gpio: Gpio | keyof T['board'] | keyof T['bcm'],
         edge: Edge,
         options: GpioInputOptions = {}
-    ) {
-        return new Watch(gpio, edge, options);
+    ): Watch {
+        const resolvedGpio = this.getGpioFromIdentifier(gpio);
+        return new Watch(resolvedGpio, edge, options);
     }
-    static pwm(gpio: Gpio, dutyCycle: number, frequency: number, options: GpioOutputOptions = {}) {
-        return new Pwm(gpio, dutyCycle, frequency, options);
+    static pwm<T extends typeof Device>(this: T, gpio: Gpio | keyof T['board'] | keyof T['bcm'], dutyCycle: number, frequency: number, options: GpioOutputOptions = {}): Pwm {
+        const resolvedGpio = this.getGpioFromIdentifier(gpio);
+        return new Pwm(resolvedGpio, dutyCycle, frequency, options);
+    }
+
+    private static getGpioFromIdentifier<T extends typeof Device>(identifier: Gpio | keyof T['board'] | keyof T['bcm']): Gpio {
+        if (typeof identifier === 'object') {
+            return identifier;
+        } else if (typeof identifier === 'string') {
+            return this.bcm[identifier];
+        } else if (typeof identifier === 'number') {
+            return this.board[identifier];
+        }
+
+        throw new Error('Invalid identifier type');
     }
 }

--- a/src/classes/Device.ts
+++ b/src/classes/Device.ts
@@ -8,7 +8,6 @@ export class Device {
     static board: Record<number, Gpio> = {};
     static bcm: Record<string, Gpio> = {};
 
-    // input<T = typeof this>(gpio: Gpio | keyof T['board'] | keyof T['bcm'] | number) {
     static input<T extends typeof Device>(this: T, gpio: Gpio | keyof T['board'] | keyof T['bcm'], options: Omit<GpioInputOptions, 'debounce'> = {}): Input {
         const resolvedGpio = this.getGpioFromIdentifier(gpio);
         return new Input(resolvedGpio, options);

--- a/src/classes/Watch.ts
+++ b/src/classes/Watch.ts
@@ -16,12 +16,10 @@ export class Watch extends EventEmitter {
         const [getter, cleanup] = bindings.watch(gpio.chip, gpio.line, options.debounce ?? 0, options.bias ?? 0, (value) => {
             if (value && (edge === Edge.Rising || edge === Edge.Both)) {
                 // Has risen to true
-                this.emit('event', value);
                 this.emit('change', value);
                 this.emit('rise', value);
             } else if (!value && (edge === Edge.Falling || edge === Edge.Both)) {
                 // Has fallen to false
-                this.emit('event', value);
                 this.emit('change', value);
                 this.emit('fall', value);
             }

--- a/test/pin.ts
+++ b/test/pin.ts
@@ -1,0 +1,2 @@
+import { NanoPi_NEO3 } from '../src';
+const pin = NanoPi_NEO3.input('GPIO0_D3');


### PR DESCRIPTION
Introduce a method for GPIO pin selection using various identifiers and eliminate the old legacy v1 event handling.