### PR TITLE
Hotfix/libgpiod_v2.1.x-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ While this library can be used on most devices, you'll need to know the chip and
 ## Prerequisites
 
 -   **libgpiod 2.x**
+    It uses [GPIO Character Device Userspace API v2](https://docs.kernel.org/userspace-api/gpio/chardev.html) that requires Linux kernel 5.10 or newer.
 
     To install libgpiod 2.x you will need the Debian repository mirror in your sources.
     You can run the script below to add it.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ While this library can be used on most devices, you'll need to know the chip and
     sudo rm /etc/apt/trusted.gpg.d/debian-archive-keyring.gpg
     ```
 
+    **Manual**
+    Alternatively, manually build libgpiod 2.2.1 from source.
+    First, uninstall libgpiod 1.x by `sudo apt remove libgpiod-dev gpiod libgpiod2`. Then, [build from source](https://libgpiod.readthedocs.io/en/latest/building.html#building). Finally, run `./autogen.sh --enable-bindings-cxx` for Node-API bindings.
+
     **Debugging**
     If after installing libgpiod you encounter issues loading libgpiod with errors like: `Error: libgpiodcxx.so.2: cannot open shared object file: No such file or directory`, you may need to update the system library cache. You can do this by running: `sudo ldconfig`
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ While this library can be used on most devices, you'll need to know the chip and
     sudo apt update
 
     # Install https://packages.debian.org/sid/libgpiod-dev
-    sudo apt install -t sid libgpiod-dev
+    sudo apt install libgpiod-dev/sid
 
     # (Optionally unlink Debian repository keyring for safety)
     sudo rm /etc/apt/trusted.gpg.d/debian-archive-keyring.gpg


### PR DESCRIPTION
Update readme for
-safer sid-based installation
-libgpiod 2.x prerequisites
-manual build from source instructions

To address issue #34