### PR TITLE
Run watch/PWM loops on dedicated threads instead of the libuv pool

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,8 +7,10 @@
             "<!@(node -p \"require('node-addon-api').include\")"
         ],  
         "libraries": [
-            "-lgpiodcxx"
+            "-lgpiodcxx",
+            "-pthread"
         ],
+        "cflags_cc": ["-pthread"],
         "cflags_cc!": ["-fno-exceptions"],
         "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
     }

--- a/cpp/opengpio.cpp
+++ b/cpp/opengpio.cpp
@@ -3,6 +3,8 @@
 #include <gpiod.hpp>
 #include <unistd.h>
 #include <uv.h>
+#include <thread>
+#include <atomic>
 using namespace std;
 
 Napi::Array GpioInput(Napi::CallbackInfo const &info)
@@ -119,7 +121,7 @@ Napi::String Info(const Napi::CallbackInfo &info)
 
 struct WatchContext
 {
-    bool active;
+    std::atomic<bool> active;
     ::gpiod::line_request *request;
     Napi::ThreadSafeFunction thread_safe_watch_callback;
 };
@@ -183,9 +185,6 @@ Napi::Array GpioWatch(Napi::CallbackInfo const &info)
     data->active = true;
     data->thread_safe_watch_callback = thread_safe_watch_callback;
 
-    uv_work_t *req = new uv_work_t;
-    req->data = data;
-
     Napi::Function getter = Napi::Function::New(info.Env(), [request, line_offset](const Napi::CallbackInfo &info)
                                                 {
     bool value = request->get_value(line_offset) == ::gpiod::line::value::ACTIVE ? true : false;
@@ -194,42 +193,41 @@ Napi::Array GpioWatch(Napi::CallbackInfo const &info)
     Napi::Function cleanup = Napi::Function::New(info.Env(), [data](const Napi::CallbackInfo &info)
                                                  { data->active = false; });
 
-    uv_queue_work(
-        uv_default_loop(), req,
-        [](uv_work_t *req)
+    // Run the blocking edge-event loop on a dedicated std::thread instead of the
+    // libuv thread pool (uv_queue_work). The pool is bounded (UV_THREADPOOL_SIZE,
+    // default 4) and this loop never returns until the watch is stopped, so one
+    // watch per pool slot would starve the pool and silently prevent additional
+    // GPIO inputs from ever receiving edge events. A dedicated thread has no such
+    // limit; the ThreadSafeFunction makes the callback safe from any thread.
+    std::thread watch_thread([data]()
+                             {
+        ::gpiod::edge_event_buffer buffer(1);
+        ::gpiod::line_request *request = data->request;
+
+        while (data->active)
         {
-            WatchContext *data = static_cast<WatchContext *>(req->data);
-            ::gpiod::edge_event_buffer buffer(1);
-            ::gpiod::line_request *request = data->request;
-
-            while (data->active)
+            bool has_event = request->wait_edge_events(chrono::milliseconds(1));
+            if (has_event)
             {
-                bool has_event = request->wait_edge_events(chrono::milliseconds(1));
-                if (has_event)
-                {
-                    request->read_edge_events(buffer);
+                request->read_edge_events(buffer);
 
-                    // ::gpiod::edge_event &event = buffer[0];
-                    for (const auto &event : buffer)
-                    {
-                        bool value = event.type() == ::gpiod::edge_event::event_type::RISING_EDGE ? true : false;
-                        data->thread_safe_watch_callback.BlockingCall(new bool(value), [](Napi::Env env, Napi::Function watch_callback, bool *value)
-                                                                      {
-                                                                    watch_callback.Call({Napi::Boolean::New(env, *value)});
-                                                                    delete value; });
-                    }
+                for (const auto &event : buffer)
+                {
+                    bool value = event.type() == ::gpiod::edge_event::event_type::RISING_EDGE ? true : false;
+                    data->thread_safe_watch_callback.BlockingCall(new bool(value), [](Napi::Env env, Napi::Function watch_callback, bool *value)
+                                                                  {
+                                                                watch_callback.Call({Napi::Boolean::New(env, *value)});
+                                                                delete value; });
                 }
             }
-        },
-        [](uv_work_t *req, int status)
-        {
-            WatchContext *data = static_cast<WatchContext *>(req->data);
-            data->thread_safe_watch_callback.Release();
-            data->request->release();
+        }
 
-            delete req;
-            delete data;
-        });
+        // The loop has been stopped via cleanup(); release resources here (the
+        // equivalent of the old uv_queue_work completion callback).
+        data->thread_safe_watch_callback.Release();
+        data->request->release();
+        delete data; });
+    watch_thread.detach();
 
     // Outputs
     Napi::Array arr = Napi::Array::New(info.Env(), 2);
@@ -244,7 +242,7 @@ struct PwmContext
     int frequency;
     double duty_cycle;
     int line_offset;
-    bool active;
+    std::atomic<bool> active;
     ::gpiod::line_request *request;
 };
 
@@ -306,42 +304,36 @@ Napi::Array GpioPwm(Napi::CallbackInfo const &info)
     data->active = true;
     data->line_offset = line_offset;
 
-    uv_work_t *req = new uv_work_t;
-    req->data = data;
+    // Run the PWM loop on a dedicated std::thread instead of the libuv thread
+    // pool (uv_queue_work); see the explanation in GpioWatch. The loop is a busy
+    // wait that never returns until stopped, so it must not occupy a bounded
+    // pool slot.
+    std::thread pwm_thread([data]()
+                           {
+        ::gpiod::line_request *request = data->request;
+        int line_offset = data->line_offset;
 
-    uv_queue_work(
-        uv_default_loop(), req,
-        [](uv_work_t *req)
+        while (data->active)
         {
-            PwmContext *data = static_cast<PwmContext *>(req->data); // Get the data
-            ::gpiod::line_request *request = data->request;
-            int line_offset = data->line_offset;
+            int frequency = data->frequency;
+            double duty_cycle = data->duty_cycle;
+            double period = 1.0 / frequency;
+            double on_time = period * duty_cycle;
+            double off_time = period - on_time;
+            long on_time_ns = on_time * 1e9;
+            long off_time_ns = off_time * 1e9;
 
-            while (data->active)
-            {
-                int frequency = data->frequency;
-                double duty_cycle = data->duty_cycle;
-                double period = 1.0 / frequency;
-                double on_time = period * duty_cycle;
-                double off_time = period - on_time;
-                long on_time_ns = on_time * 1e9;
-                long off_time_ns = off_time * 1e9;
+            request->set_value(line_offset, ::gpiod::line::value::ACTIVE);
+            WaitBlocking(on_time_ns);
 
-                request->set_value(line_offset, ::gpiod::line::value::ACTIVE);
-                WaitBlocking(on_time_ns);
+            request->set_value(line_offset, ::gpiod::line::value::INACTIVE);
+            WaitBlocking(off_time_ns);
+        }
 
-                request->set_value(line_offset, ::gpiod::line::value::INACTIVE);
-                WaitBlocking(off_time_ns);
-            }
-        },
-        [](uv_work_t *req, int status)
-        {
-            PwmContext *data = static_cast<PwmContext *>(req->data);
-            data->request->release();
-
-            delete req;
-            delete data;
-        });
+        // Stopped via cleanup(); release resources here.
+        data->request->release();
+        delete data; });
+    pwm_thread.detach();
 
     Napi::Function duty_cycle_setter = Napi::Function::New(info.Env(), [data](const Napi::CallbackInfo &info)
                                                            {


### PR DESCRIPTION
## Problem

`GpioWatch` and `GpioPwm` dispatch their endless loops via `uv_queue_work()`,
which schedules work on the **libuv thread pool**. That pool is bounded by
`UV_THREADPOOL_SIZE` (default **4**), and neither loop ever returns until the
line is stopped — each is a `while (active) { ... }` that blocks its worker
for the entire lifetime of the watch/PWM.

Result: every active watch permanently occupies one pool slot. Once more than
`UV_THREADPOOL_SIZE` lines are watched, the surplus watches are *queued but
never start*, so those GPIOs silently stop emitting edge events. They appear to
work again only after a restart re-shuffles which lines happen to get a slot.
The same limit applies to concurrent PWM outputs, and the watches also compete
with the pool's normal users (fs/dns/crypto).

This was hit in the wild by the ioBroker rpi2 adapter: exactly 4 GPIO inputs
update live, the 5th never does.
Downstream report: https://github.com/iobroker-community-adapters/ioBroker.rpi2/issues/378

## Fix

Run each loop on its own **detached `std::thread`** instead of the libuv pool.
The callback already uses a `Napi::ThreadSafeFunction`, which is designed to be
called from any thread, so no pool slot is consumed and the number of
concurrent watches/PWMs is no longer capped.

- Resource release that previously happened in the `uv_queue_work` completion
  callback now runs at the end of the thread, once the loop is stopped via
  `cleanup()`.
- `active` is now `std::atomic<bool>` — written from the JS thread (`cleanup`),
  read from the worker thread.
- `binding.gyp` gains `-pthread` for `std::thread` linkage.

No public API or JS/TS changes — `watch()`/`output()`/`pwm()` behave the same,
just without the 4-line ceiling.

## Testing

- Built and ran on a Raspberry Pi (Debian Trixie, libgpiod 2.x).
- Verified >4 simultaneous input watches all deliver edge events live (via the
  ioBroker rpi2 adapter), which was impossible before.

Reported downstream at
https://github.com/iobroker-community-adapters/ioBroker.rpi2/issues/378

For transparency:
This PR was done with the help of Claude Opus 4.8 - personally I am an experienced developer and had a look at its changes and tested what it did. But I am not very knowledgeable around C++/std:thread myself, so I can mostly just confirm it builds and does what Claude claims it should do and don't see any very obvious shenanigans. 